### PR TITLE
Update general.py

### DIFF
--- a/yolov5/utils/general.py
+++ b/yolov5/utils/general.py
@@ -517,7 +517,7 @@ def check_dataset(data, autodownload=True):
 
 def check_amp(model):
     # Check PyTorch Automatic Mixed Precision (AMP) functionality. Return True on correct operation
-    from models.common import AutoShape, DetectMultiBackend
+    from yolov5.models.common import AutoShape, DetectMultiBackend
 
     def amp_allclose(model, im):
         # All close FP32 vs AMP results


### PR DESCRIPTION
Code fails when you want to continue model training from a checkpoint using a flag --resume.

Let's say you trained a model for 10 epochs and training stopped for some reason. Now you want to resume training by providing a path to the checkpoint using a flag --resume package fails with an error:

```
    531 def check_amp(model):
    532     # Check PyTorch Automatic Mixed Precision (AMP) functionality. Return True on correct operation
--> 533     from models.common import AutoShape, DetectMultiBackend
    535     def amp_allclose(model, im):
    536         # All close FP32 vs AMP results
    537         m = AutoShape(model, verbose=False)  # model

ModuleNotFoundError: No module named 'models'
```
To resolve this issue and to be able to continue model training I replaced the import statement.


If my PR lacks details, please let me know, I will update it ASAP.
