### PR TITLE
Supports directly calling the scripts without installing the package

### DIFF
--- a/yolov5/cli.py
+++ b/yolov5/cli.py
@@ -26,3 +26,6 @@ def app() -> None:
             'segment': {'train': segment_train, 'val': segment_val, 'predict': segment_predict},
         }
     )
+
+if __name__ == "__main__":
+    app()

--- a/yolov5/segment/train.py
+++ b/yolov5/segment/train.py
@@ -673,4 +673,4 @@ def run_cli(**kwargs):
 
 
 if __name__ == "__main__":
-    main()
+    main(parse_opt())

--- a/yolov5/segment/val.py
+++ b/yolov5/segment/val.py
@@ -479,4 +479,4 @@ def main(opt):
 
 
 if __name__ == "__main__":
-    main()
+    main(parse_opt())


### PR DESCRIPTION
I'm looking at this repo for the segmentation task. There are cases where I would prefer to run the yolov5/segment/train.py etc. scripts directly without installing this package, so this PR allows us to run those scripts directly similar to how the original repo behaves.