### PR TITLE
Fixed bug in precision logic

### DIFF
--- a/yolov5/val.py
+++ b/yolov5/val.py
@@ -170,7 +170,7 @@ def run(
 
     # Configure
     model.eval()
-    half = cuda = device.type != 'cpu' # half precision only supported on CUDA, dont remove!
+    cuda = device.type != 'cpu' # half precision only supported on CUDA, dont remove!
     is_coco = isinstance(data.get('val'), str) and data['val'].endswith(f'coco{os.sep}val2017.txt')  # COCO dataset
     nc = 1 if single_cls else int(data['nc'])  # number of classes
     iouv = torch.linspace(0.5, 0.95, 10, device=device)  # iou vector for mAP@0.5:0.95


### PR DESCRIPTION
My change here aligns val() with the impimentation in upstream.  Without my change, the data samples will ALWAYS be cast to half when run on CUDA.  However, the model may not be half precision in this case as per the logic above this section (The "if training: ... else: ...", specifically lines 145&149).  This means the code ALWAYS crashes when run on CUDA when not passing --half as the model weights will be normal precision, but all input will be half precision.

My change ensures that weights and input have same precision.  Additionally, half precision is used if and only if --half is passed, the devices is not cpu, and the specific backend supports half precision