### PR TITLE
Limit max version of hugginface_hub to fix import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,6 @@ boto3>=1.19.1
 # coco to yolov5 conversion
 sahi>=0.11.10
 # huggingface
-huggingface-hub>=0.12.0
+huggingface-hub>=0.12.0,<0.25.0
 # roboflow
 roboflow>=0.2.29


### PR DESCRIPTION
- Fixes error: `no module named 'huggingface_hub.utils._errors`
- Fixes all failing CI jobs: https://github.com/jc-roman/yolov5-pip/actions/runs/11753972732